### PR TITLE
Changed test case authorize_url to authenticate based on issue #4 change

### DIFF
--- a/spec/omniauth/strategies/foursquare_spec.rb
+++ b/spec/omniauth/strategies/foursquare_spec.rb
@@ -21,7 +21,7 @@ describe OmniAuth::Strategies::Foursquare do
     end
 
     it 'has correct authorize url' do
-      subject.client.options[:authorize_url].should eq('/oauth2/authorize')
+      subject.client.options[:authorize_url].should eq('/oauth2/authenticate')
     end
 
     it 'has correct token url' do


### PR DESCRIPTION
Issue #4 introduced a change to the authorize_url from /authorize to /authenticate, but the related test case was not updated to show these changes.

All tests will pass based on this change to confirm authorize_url is equal to /authenticate.
