### PR TITLE
Added Image and Location to Auth Hash Info

### DIFF
--- a/lib/omniauth/strategies/foursquare.rb
+++ b/lib/omniauth/strategies/foursquare.rb
@@ -16,7 +16,9 @@ module OmniAuth
           :first_name => raw_info['firstName'], 
           :last_name  => raw_info['lastName'],
           :name       => raw_info['name'],
-          :email      => (raw_info['contact'] || {})['email']
+          :email      => (raw_info['contact'] || {})['email'],
+          :image      => raw_info['photo'],
+          :location   => raw_info['homeCity']
         }
       end
       

--- a/spec/omniauth/strategies/foursquare_spec.rb
+++ b/spec/omniauth/strategies/foursquare_spec.rb
@@ -37,7 +37,9 @@ describe OmniAuth::Strategies::Foursquare do
         'lastName' => 'Smith',
         'contact' => {
           'email' => 'fred@example.com'
-        }
+        },
+        'photo' => 'https://img-s.foursquare.com/userpix_thumbs/blank_boy.jpg',
+        'homeCity' => 'Chicago'
       }
       subject.stub(:raw_info) { @raw_info }
     end
@@ -62,6 +64,14 @@ describe OmniAuth::Strategies::Foursquare do
       it "sets the email blank if contact block is missing in raw_info" do
         @raw_info.delete('contact')
         subject.info[:email].should be_nil
+      end
+
+      it 'returns the user image' do
+        subject.info[:image].should eq('https://img-s.foursquare.com/userpix_thumbs/blank_boy.jpg')
+      end
+
+      it 'returns the user location' do
+        subject.info[:location].should eq('Chicago')
       end
     end
   end


### PR DESCRIPTION
The Auth Hash Schema states that the Info hash contains information on the location and image of a given user. https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema

Foursquare makes this data available within the User response as photo and homeCity. https://developer.foursquare.com/docs/explore#req=users/self

This mapping was previously not available within the master branch for omniauth-foursquare. I've added the mapping, along with 2 passing test cases for image and location.
