### PR TITLE
Prevent unnecessary API requests

### DIFF
--- a/lib/omniauth/strategies/foursquare.rb
+++ b/lib/omniauth/strategies/foursquare.rb
@@ -39,8 +39,7 @@ module OmniAuth
       def raw_info
         access_token.options[:mode] = :query
         access_token.options[:param_name] = :oauth_token
-        response = access_token.get('https://api.foursquare.com/v2/users/self').parsed['response']
-        @raw_info ||= response['user']
+        @raw_info ||= access_token.get('https://api.foursquare.com/v2/users/self').parsed['response']['user']
       end
       
       private


### PR DESCRIPTION
As is, the omniauth-foursquare strategy makes numerous, identical HTTP GET requests to the Foursquare API when populating `raw_info`. This is happening because the actual API request is not on the rhs of the `||=` operator.

I've simply updated the `raw_info` method to put the API request code on the rhs of the `||=` operator so it can be skipped if `@raw_info` is already populated.

Not submitting any test cases since no functionality is changed.
