### PR TITLE
Add Version params to access_token call

### DIFF
--- a/lib/omniauth/strategies/foursquare.rb
+++ b/lib/omniauth/strategies/foursquare.rb
@@ -39,7 +39,7 @@ module OmniAuth
       def raw_info
         access_token.options[:mode] = :query
         access_token.options[:param_name] = :oauth_token
-        @raw_info ||= access_token.get('https://api.foursquare.com/v2/users/self').parsed['response']['user']
+        @raw_info ||= access_token.get('https://api.foursquare.com/v2/users/self?v=20140128').parsed['response']['user']
       end
       
       private


### PR DESCRIPTION
As of January 28, 2014, requests that do not include a v parameter will be rejected.

https://developer.foursquare.com/overview/versioning
