### PR TITLE
Update OmniAuth Info Hash with more info from Foursquare API

### DIFF
--- a/lib/omniauth/strategies/foursquare.rb
+++ b/lib/omniauth/strategies/foursquare.rb
@@ -13,12 +13,14 @@ module OmniAuth
 
       info do
         {
-          :first_name => raw_info['firstName'],
-          :last_name  => raw_info['lastName'],
-          :name       => "#{raw_info['firstName']} #{raw_info['lastName']}",
-          :email      => (raw_info['contact'] || {})['email'],
-          :image      => raw_info['photo'],
-          :location   => raw_info['homeCity']
+          :first_name  => raw_info['firstName'],
+          :last_name   => raw_info['lastName'],
+          :name        => "#{raw_info['firstName']} #{raw_info['lastName']}",
+          :email       => (raw_info['contact'] || {})['email'],
+          :phone       => (raw_info['contact'] || {})['phone'],
+          :image       => raw_info['photo'],
+          :location    => raw_info['homeCity'],
+          :description => raw_info['bio']
         }
       end
 

--- a/spec/omniauth/strategies/foursquare_spec.rb
+++ b/spec/omniauth/strategies/foursquare_spec.rb
@@ -35,10 +35,12 @@ describe OmniAuth::Strategies::Foursquare do
         'firstName' => 'Fred',
         'lastName' => 'Smith',
         'contact' => {
-          'email' => 'fred@example.com'
+          'email' => 'fred@example.com',
+          'phone' => '+1 555 555-5555',
         },
         'photo' => 'https://img-s.foursquare.com/userpix_thumbs/blank_boy.jpg',
-        'homeCity' => 'Chicago'
+        'homeCity' => 'Chicago',
+        'bio' => 'I am a guy from Chicago.'
       }
       subject.stub(:raw_info) { @raw_info }
     end
@@ -60,6 +62,10 @@ describe OmniAuth::Strategies::Foursquare do
         subject.info[:email].should eq('fred@example.com')
       end
 
+      it 'returns the phone number' do
+        subject.info[:phone].should eq('+1 555 555-5555')
+      end
+
       it "sets the email blank if contact block is missing in raw_info" do
         @raw_info.delete('contact')
         subject.info[:email].should be_nil
@@ -71,6 +77,10 @@ describe OmniAuth::Strategies::Foursquare do
 
       it 'returns the user location' do
         subject.info[:location].should eq('Chicago')
+      end
+
+      it 'returns the user description' do
+        subject.info[:description].should eq('I am a guy from Chicago.')
       end
     end
   end


### PR DESCRIPTION
Foursquare doesn't provide a 'name' field in their API response for users, so using that field to fill 'name' in the Auth Hash always ends up being nil. This field is required, per the [Auth Hash Schema](https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema).

The commit to fix the name field isn't mine, but seems to solve the issue nicely.

Additionally, we can pull in the bio and phone number from the Foursquare response, so I added these as well.
