### PR TITLE
Fixed broken callback due to the way foursquare returns image

### DIFF
--- a/lib/omniauth/strategies/foursquare.rb
+++ b/lib/omniauth/strategies/foursquare.rb
@@ -18,7 +18,7 @@ module OmniAuth
           :name        => "#{raw_info['firstName']} #{raw_info['lastName']}",
           :email       => (raw_info['contact'] || {})['email'],
           :phone       => (raw_info['contact'] || {})['phone'],
-          :image       => raw_info['photo'],
+          :image       => "#{[raw_info['photo']['prefix'], raw_info['photo']['suffix']].join}",
           :location    => raw_info['homeCity'],
           :description => raw_info['bio']
         }

--- a/lib/omniauth/strategies/foursquare.rb
+++ b/lib/omniauth/strategies/foursquare.rb
@@ -18,7 +18,7 @@ module OmniAuth
           :name        => "#{raw_info['firstName']} #{raw_info['lastName']}",
           :email       => (raw_info['contact'] || {})['email'],
           :phone       => (raw_info['contact'] || {})['phone'],
-          :image       => "#{[raw_info['photo']['prefix'], raw_info['photo']['suffix']].join}",
+          :image       => "#{[raw_info['photo']['prefix'], '73x73', raw_info['photo']['suffix']].join}",
           :location    => raw_info['homeCity'],
           :description => raw_info['bio']
         }


### PR DESCRIPTION
For more details see - https://github.com/arunagw/omniauth-foursquare/issues/18.
By default 73x73 image size is being used.
